### PR TITLE
Bake API_URL into image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     env:
       GIT_REF: ${{ github.ref }}
       API_URL: https://api-sandbox.lolcatz.tv
+      DOCKER_REGISTRY: docker.pkg.github.com
     steps:
       - uses: actions/checkout@v1
       - uses: azure/docker-login@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,10 @@ jobs:
           username: x-access-token
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and test
-        run: npm run build
+        run: |
+          npm install --silent
+          npm install react-scripts@3.3.0
+          npm run build
       - name: Build and push docker image
         run: VERSION="${GITHUB_SHA:0:8}-sandbox" make build publish
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
           login-server: ${{ env.DOCKER_REGISTRY }}
           username: x-access-token
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and test
+        run: npm run build
       - name: Build and push docker image
         run: VERSION="${GITHUB_SHA:0:8}-sandbox" make build publish
-        if: github.ref == 'refs/heads/build-test'
+        if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,4 +20,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push docker image
         run: VERSION="${GITHUB_SHA:0:8}-sandbox" make build publish
-        if: github.ref === "refs/heads/build-test"
+        if: github.ref == "refs/heads/build-test"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,14 @@ jobs:
     runs-on: ubuntu-18.04
     env:
       GIT_REF: ${{ github.ref }}
+      API_URL: https://api-sandbox.lolcatz.tv
     steps:
       - uses: actions/checkout@v1
-      - name: npm build
-        run: |
-          npm install --silent
-          npm install react-scripts@3.3.0
-          npm run build
+      - uses: azure/docker-login@v1
+        with:
+          login-server: ${{ env.DOCKER_REGISTRY }}
+          username: x-access-token
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push docker image
+        run: VERSION="${GITHUB_SHA:0:8}-sandbox" make build publish
+        if: github.ref === "refs/heads/build-test"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,4 +20,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push docker image
         run: VERSION="${GITHUB_SHA:0:8}-sandbox" make build publish
-        if: github.ref == "refs/heads/build-test"
+        if: github.ref == 'refs/heads/build-test'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DOCKER_REGISTRY: docker.pkg.github.com
+      API_URL: https://api.lolcatz.tv
     steps:
       - uses: actions/checkout@v2
       - uses: azure/docker-login@v1
@@ -18,5 +19,5 @@ jobs:
           login-server: ${{ env.DOCKER_REGISTRY }}
           username: x-access-token
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build docker image
-        run: TAG=${GITHUB_REF#refs/tags/} make docker-build docker-push
+      - name: Build and push docker image
+        run: VERSION="${GITHUB_REF#refs/tags/}-production" make build publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,19 @@
 # build environment
 FROM node:12-alpine as builder
-WORKDIR /app
+
+ARG API_URL
+
 ENV PATH /app/node_modules/.bin:$PATH
+ENV REACT_APP_API_URL=${API_URL}
+
+RUN echo "API_URL: ${REACT_APP_API_URL}"
+
+WORKDIR /app
+
 COPY package.json /app/package.json
 RUN npm install --silent
 RUN npm install react-scripts@3.3.0 -g --silent
+
 COPY . /app
 RUN npm run build
 

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,18 @@
-REPO ?= $(shell git remote get-url origin | sed 's/.*github\.com[\/:]\{1\}//' | sed 's/\.git$$//')
-TAG ?= $(shell git rev-parse --short HEAD)
-IMAGE_NAME ?= webapp
+GIT_REPO ?= $(shell git remote get-url origin | sed 's/.*github\.com[\/:]\{1\}//' | sed 's/\.git$$//')
+VERSION ?= $(shell git rev-parse --short HEAD)-dev
+NAME ?= webapp
+API_URL ?= http://localhost:8000
 
 ifdef DOCKER_REGISTRY
-	IMAGE := $(DOCKER_REGISTRY)/$(REPO)/$(IMAGE_NAME):$(TAG)
+	IMAGE_TAG := $(DOCKER_REGISTRY)/$(GIT_REPO)/$(NAME):$(VERSION)
 else
-	IMAGE := $(REPO)/$(IMAGE_NAME):$(TAG)
+	IMAGE_TAG := $(GIT_REPO)/$(NAME):$(VERSION)
 endif
 
-docker-build:
-	docker build -t $(IMAGE) .
-
-docker-push:
-	docker push $(IMAGE)
-
 build:
-	npm run build
+	docker build -t $(IMAGE_TAG) --build-arg API_URL=$(API_URL) .
 
-clean:
-	rm -rf build
+publish:
+	docker push $(IMAGE_TAG)
 
-.PHONY: clean build docker-build docker-push
+.PHONY: clean build publish

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,9 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 
-const API_URL="http://localhost:8000";
+// Passed at build time, see https://create-react-app.dev/docs/adding-custom-environment-variables/
+const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000";
+
 
 class UploadButton extends React.Component {
 


### PR DESCRIPTION
Parameterize API_URL via https://create-react-app.dev/docs/adding-custom-environment-variables/. Still kinda clunky since images are now tied to specific URLs. Alternative would be to bake the build step into the image and build the app on launch so we can set the API URL as an env var at deployment time. 